### PR TITLE
Fix path for Xamarin.MonoTouch.FSharp.targets

### DIFF
--- a/Shallow/Shallow.fsproj
+++ b/Shallow/Shallow.fsproj
@@ -124,7 +124,7 @@
     <Compile Include="ShallowViewController.fs" />
     <Compile Include="AppDelegate.fs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.FSharp.targets" />
   <ItemGroup>
     <BundleResource Include="Resources\Default-568h%402x.png" />
     <BundleResource Include="Resources\nope-icon%402x.png" />


### PR DESCRIPTION
fsproj file fails to build in recent Xamarin Studio installations. Updating path fixes issue.
